### PR TITLE
subscribe: file backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.12.x
   - 1.13.x
+  - 1.14.x
 env:
   - GO111MODULE=on
 services:

--- a/example_test.go
+++ b/example_test.go
@@ -50,7 +50,7 @@ func ExampleSubscriber() {
 
 	handler := bps.HandlerFunc(func(msg bps.SubMessage) error {
 		fmt.Printf("%s\n", msg.Data())
-		return nil
+		return nil // or bps.Done to stop/unsubscribe
 	})
 
 	// blocks till all the messages are consumed or error occurs:

--- a/file/example_test.go
+++ b/file/example_test.go
@@ -71,7 +71,7 @@ func ExampleSubscriber() {
 	}
 
 	// Output:
-	// {"data":"bWVzc2FnZQ=="}
+	// message
 }
 
 func SeedTopic(ctx context.Context, dir, topic string) {

--- a/file/file.go
+++ b/file/file.go
@@ -148,14 +148,14 @@ func (s *fileSub) Subscribe(ctx context.Context, topic string, handler bps.Handl
 			return err
 		}
 
-		var rec json.RawMessage
-		if err := dec.Decode(&rec); errors.Is(err, io.EOF) {
+		var msg subMessage
+		if err := dec.Decode(&msg); errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return err
 		}
 
-		if err := handler.Handle(subMessage(rec)); errors.Is(err, bps.Done) {
+		if err := handler.Handle(msg); errors.Is(err, bps.Done) {
 			break
 		} else if err != nil {
 			return err
@@ -168,6 +168,6 @@ func (s *fileSub) Close() error {
 	return nil
 }
 
-type subMessage []byte
+type subMessage struct{ bps.PubMessage }
 
-func (m subMessage) Data() []byte { return m }
+func (m subMessage) Data() []byte { return m.PubMessage.Data }

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Subscriber", func() {
 			}
 		})
 
-		lint.Subcriber(&shared)
+		lint.Subscriber(&shared)
 	})
 })
 

--- a/internal/lint/subscribe.go
+++ b/internal/lint/subscribe.go
@@ -25,8 +25,8 @@ type SubscriberInput struct {
 	Teardown func(topic string) error
 }
 
-// Subcriber lints subscribers.
-func Subcriber(input *SubscriberInput) {
+// Subscriber lints subscribers.
+func Subscriber(input *SubscriberInput) {
 	var subject bps.Subscriber
 	var handler *mockHandler
 	var ctx = context.Background()

--- a/internal/lint/subscribe.go
+++ b/internal/lint/subscribe.go
@@ -13,16 +13,9 @@ import (
 
 // SubscriberInput for the shared test.
 type SubscriberInput struct {
-	// Subject holds a subscriber to be tested.
-	Subject bps.Subscriber
-	// SeededMessages contain all the messages, seeded for this subscriber.
-	// Must contain at 2+ messages.
-	// Seed/consume order must be preserved.
-	SeededMessages []bps.SubMessage
-	// Setup is called before testing the subscriber.
-	Setup func(topic string) error
-	// Teardown is called after testing the subscriber.
-	Teardown func(topic string) error
+	// Subject should return a subject to be tested, with given topic/messages seeded.
+	// Caller should handle all the subject teardown/cleanup.
+	Subject func(topic string, messages []bps.SubMessage) bps.Subscriber
 }
 
 // Subscriber lints subscribers.
@@ -32,71 +25,70 @@ func Subscriber(input *SubscriberInput) {
 	var ctx = context.Background()
 
 	var (
-		knownTopic   string
+		topic        string
 		unknownTopic string
 	)
 
 	ginkgo.BeforeEach(func() {
-		// sanity check - require at least 2 messages seeded for subscriber for proper stop/abort testing:
-		Ω.Expect(input.SeededMessages).To(Ω.HaveLen(2))
-
-		subject = input.Subject
-		handler = &mockHandler{}
-
 		cycle := time.Now().UnixNano()
-		knownTopic = fmt.Sprintf("bps-unittest-topic-%d-a", cycle)
+		topic = fmt.Sprintf("bps-unittest-topic-%d-a", cycle)
 		unknownTopic = fmt.Sprintf("bps-unittest-topic-%d-unknown", cycle)
 
-		if input.Setup != nil {
-			Ω.Expect(input.Setup(knownTopic)).To(Ω.Succeed())
-		}
-	})
-
-	ginkgo.AfterEach(func() {
-		if input.Teardown != nil {
-			Ω.Expect(input.Teardown(knownTopic)).To(Ω.Succeed())
-		}
+		subject = input.Subject(topic, []bps.SubMessage{
+			bps.RawSubMessage("message-1"),
+			bps.RawSubMessage("message-2"),
+		})
+		handler = &mockHandler{}
 	})
 
 	ginkgo.It("should subscribe", func() {
-		Ω.Expect(subject.Subscribe(ctx, knownTopic, handler)).To(Ω.Succeed())
-		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal(extractDatas(input.SeededMessages)))
+		Ω.Expect(subject.Subscribe(ctx, topic, handler)).To(Ω.Succeed())
+		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal([][]byte{
+			[]byte("message-1"),
+			[]byte("message-2"),
+		}))
 	})
 
 	ginkgo.It("should stop on bps.Done", func() {
 		// allow error wrapping:
 		handler.Err = fmt.Errorf("wrapped %w", bps.Done)
 
-		Ω.Expect(subject.Subscribe(ctx, knownTopic, handler)).To(Ω.Succeed())
+		Ω.Expect(subject.Subscribe(ctx, topic, handler)).To(Ω.Succeed())
 
 		// only first message handled - before error is returned:
-		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal(extractDatas(input.SeededMessages[0:1])))
+		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal([][]byte{
+			[]byte("message-1"),
+		}))
 	})
 
 	ginkgo.It("should return handler error", func() {
 		expectedErr := errors.New("foo")
 		handler.Err = expectedErr
 
-		actualErr := subject.Subscribe(ctx, knownTopic, handler)
+		actualErr := subject.Subscribe(ctx, topic, handler)
 
 		// allow error wrapping:
 		Ω.Expect(errors.Is(actualErr, expectedErr)).To(Ω.BeTrue())
 
 		// only first message handled - before error is returned:
-		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal(extractDatas(input.SeededMessages[0:1])))
+		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal([][]byte{
+			[]byte("message-1"),
+		}))
 	})
 
 	ginkgo.It("should stop when context is cancelled", func() {
 		cancellableCtx, cancel := context.WithCancel(ctx)
 		handler.AfterHandle = cancel
 
-		err := subject.Subscribe(cancellableCtx, knownTopic, handler)
+		err := subject.Subscribe(cancellableCtx, topic, handler)
 
 		// allow error wrapping:
 		Ω.Expect(errors.Is(err, context.Canceled)).To(Ω.BeTrue())
 
 		// only first message handled - before context is cancelled:
-		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal(extractDatas(input.SeededMessages[0:1])))
+		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal([][]byte{
+			[]byte("message-1"),
+		}))
 	})
 
 	ginkgo.It("should do nothing for unknown topicss", func() {

--- a/internal/lint/subscribe.go
+++ b/internal/lint/subscribe.go
@@ -43,7 +43,7 @@ func Subscriber(input *SubscriberInput) {
 
 	ginkgo.It("should subscribe", func() {
 		Ω.Expect(subject.Subscribe(ctx, topic, handler)).To(Ω.Succeed())
-		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal([][]byte{
+		Ω.Expect(extractData(handler.Received)).To(Ω.Equal([][]byte{
 			[]byte("message-1"),
 			[]byte("message-2"),
 		}))
@@ -56,7 +56,7 @@ func Subscriber(input *SubscriberInput) {
 		Ω.Expect(subject.Subscribe(ctx, topic, handler)).To(Ω.Succeed())
 
 		// only first message handled - before error is returned:
-		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal([][]byte{
+		Ω.Expect(extractData(handler.Received)).To(Ω.Equal([][]byte{
 			[]byte("message-1"),
 		}))
 	})
@@ -71,7 +71,7 @@ func Subscriber(input *SubscriberInput) {
 		Ω.Expect(errors.Is(actualErr, expectedErr)).To(Ω.BeTrue())
 
 		// only first message handled - before error is returned:
-		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal([][]byte{
+		Ω.Expect(extractData(handler.Received)).To(Ω.Equal([][]byte{
 			[]byte("message-1"),
 		}))
 	})
@@ -86,7 +86,7 @@ func Subscriber(input *SubscriberInput) {
 		Ω.Expect(errors.Is(err, context.Canceled)).To(Ω.BeTrue())
 
 		// only first message handled - before context is cancelled:
-		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal([][]byte{
+		Ω.Expect(extractData(handler.Received)).To(Ω.Equal([][]byte{
 			[]byte("message-1"),
 		}))
 	})
@@ -111,10 +111,10 @@ func (h *mockHandler) Handle(msg bps.SubMessage) error {
 	return h.Err
 }
 
-func extractDatas(msgs []bps.SubMessage) [][]byte {
-	datas := make([][]byte, 0, len(msgs))
+func extractData(msgs []bps.SubMessage) [][]byte {
+	data := make([][]byte, 0, len(msgs))
 	for _, msg := range msgs {
-		datas = append(datas, msg.Data())
+		data = append(data, msg.Data())
 	}
-	return datas
+	return data
 }

--- a/internal/lint/subscribe.go
+++ b/internal/lint/subscribe.go
@@ -1,0 +1,128 @@
+package lint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bsm/bps"
+	"github.com/onsi/ginkgo"
+	Ω "github.com/onsi/gomega"
+)
+
+// SubscriberInput for the shared test.
+type SubscriberInput struct {
+	// Subject holds a subscriber to be tested.
+	Subject bps.Subscriber
+	// SeededMessages contain all the messages, seeded for this subscriber.
+	// Must contain at 2+ messages.
+	// Seed/consume order must be preserved.
+	SeededMessages []bps.SubMessage
+	// Setup is called before testing the subscriber.
+	Setup func(topic string) error
+	// Teardown is called after testing the subscriber.
+	Teardown func(topic string) error
+}
+
+// Subcriber lints subscribers.
+func Subcriber(input *SubscriberInput) {
+	var subject bps.Subscriber
+	var handler *mockHandler
+	var ctx = context.Background()
+
+	var (
+		knownTopic   string
+		unknownTopic string
+	)
+
+	ginkgo.BeforeEach(func() {
+		// sanity check - require at least 2 messages seeded for subscriber for proper stop/abort testing:
+		Ω.Expect(input.SeededMessages).To(Ω.HaveLen(2))
+
+		subject = input.Subject
+		handler = &mockHandler{}
+
+		cycle := time.Now().UnixNano()
+		knownTopic = fmt.Sprintf("bps-unittest-topic-%d-a", cycle)
+		unknownTopic = fmt.Sprintf("bps-unittest-topic-%d-unknown", cycle)
+
+		if input.Setup != nil {
+			Ω.Expect(input.Setup(knownTopic)).To(Ω.Succeed())
+		}
+	})
+
+	ginkgo.AfterEach(func() {
+		if input.Teardown != nil {
+			Ω.Expect(input.Teardown(knownTopic)).To(Ω.Succeed())
+		}
+	})
+
+	ginkgo.It("should subscribe", func() {
+		Ω.Expect(subject.Subscribe(ctx, knownTopic, handler)).To(Ω.Succeed())
+		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal(extractDatas(input.SeededMessages)))
+	})
+
+	ginkgo.It("should stop on bps.Done", func() {
+		// allow error wrapping:
+		handler.Err = fmt.Errorf("wrapped %w", bps.Done)
+
+		Ω.Expect(subject.Subscribe(ctx, knownTopic, handler)).To(Ω.Succeed())
+
+		// only first message handled - before error is returned:
+		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal(extractDatas(input.SeededMessages[0:1])))
+	})
+
+	ginkgo.It("should return handler error", func() {
+		expectedErr := errors.New("foo")
+		handler.Err = expectedErr
+
+		actualErr := subject.Subscribe(ctx, knownTopic, handler)
+
+		// allow error wrapping:
+		Ω.Expect(errors.Is(actualErr, expectedErr)).To(Ω.BeTrue())
+
+		// only first message handled - before error is returned:
+		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal(extractDatas(input.SeededMessages[0:1])))
+	})
+
+	ginkgo.It("should stop when context is cancelled", func() {
+		cancellableCtx, cancel := context.WithCancel(ctx)
+		handler.AfterHandle = cancel
+
+		err := subject.Subscribe(cancellableCtx, knownTopic, handler)
+
+		// allow error wrapping:
+		Ω.Expect(errors.Is(err, context.Canceled)).To(Ω.BeTrue())
+
+		// only first message handled - before context is cancelled:
+		Ω.Expect(extractDatas(handler.Received)).To(Ω.Equal(extractDatas(input.SeededMessages[0:1])))
+	})
+
+	ginkgo.It("should do nothing for unknown topicss", func() {
+		Ω.Expect(subject.Subscribe(ctx, unknownTopic, handler)).To(Ω.Succeed())
+		Ω.Expect(handler.Received).To(Ω.BeEmpty())
+	})
+}
+
+type mockHandler struct {
+	Err         error  // error to return after handling (first) message
+	AfterHandle func() // after message handled callback
+	Received    []bps.SubMessage
+}
+
+func (h *mockHandler) Handle(msg bps.SubMessage) error {
+	h.Received = append(h.Received, msg)
+	if cb := h.AfterHandle; cb != nil {
+		cb()
+	}
+	return h.Err
+}
+
+func extractDatas(msgs []bps.SubMessage) [][]byte {
+	datas := make([][]byte, 0, len(msgs))
+	for _, msg := range msgs {
+		datas = append(datas, msg.Data())
+	}
+	return datas
+}

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -2,6 +2,7 @@ package pubsub_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -11,9 +12,10 @@ import (
 	"github.com/bsm/bps"
 	"github.com/bsm/bps/internal/lint"
 	"github.com/bsm/bps/pubsub"
+	"google.golang.org/api/iterator"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"google.golang.org/api/iterator"
 )
 
 var _ = Describe("Publisher", func() {
@@ -74,7 +76,15 @@ func sandboxCheck() error {
 	if err != nil {
 		return err
 	}
-	return psc.Close()
+	defer psc.Close()
+
+	topic, err := psc.CreateTopic(ctx, fmt.Sprintf("bps-unittest-ping-%d", time.Now().UnixNano()))
+	if err != nil {
+		return err
+	}
+	defer topic.Delete(ctx)
+
+	return nil
 }
 
 func readMessages(topic string, max int) ([]*bps.PubMessage, error) {

--- a/subscribe.go
+++ b/subscribe.go
@@ -107,7 +107,7 @@ type InMemSubscriber struct {
 func NewInMemSubscriber(messagesByTopic map[string][]SubMessage) *InMemSubscriber {
 	byTopic := make(map[string][]SubMessage, len(messagesByTopic))
 	for topic, msgs := range messagesByTopic {
-		byTopic[topic] = append(make([]SubMessage, 0, len(msgs)), msgs...)
+		byTopic[topic] = msgs
 	}
 	return &InMemSubscriber{
 		msgs: byTopic,

--- a/subscribe.go
+++ b/subscribe.go
@@ -2,6 +2,7 @@ package bps
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"sync"
@@ -127,7 +128,9 @@ func (s *InMemSubscriber) Subscribe(ctx context.Context, topic string, handler H
 			return nil
 		}
 
-		if err := handler.Handle(msg); err != nil {
+		if err := handler.Handle(msg); errors.Is(err, Done) {
+			return nil
+		} else if err != nil {
 			return err
 		}
 	}

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/bsm/bps/internal/lint"
-
 	"github.com/bsm/bps"
+	"github.com/bsm/bps/internal/lint"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -2,8 +2,9 @@ package bps_test
 
 import (
 	"context"
-	"errors"
 	"net/url"
+
+	"github.com/bsm/bps/internal/lint"
 
 	"github.com/bsm/bps"
 
@@ -41,59 +42,21 @@ var _ = Describe("RegisterSubscriber", func() {
 })
 
 var _ = Describe("InMemSubscriber", func() {
-	var subject *bps.InMemSubscriber
+	Context("lint", func() {
+		var shared lint.SubscriberInput
 
-	ctx := context.Background()
-
-	noop := bps.HandlerFunc(func(bps.SubMessage) error { return nil })
-
-	BeforeEach(func() {
-		subject = bps.NewInMemSubscriber(
-			map[string][]bps.SubMessage{
-				"foo": []bps.SubMessage{
-					bps.RawSubMessage("foo1"),
-					bps.RawSubMessage("foo2"),
+		BeforeEach(func() {
+			shared = lint.SubscriberInput{
+				Subject: func(topic string, messages []bps.SubMessage) bps.Subscriber {
+					return bps.NewInMemSubscriber(
+						map[string][]bps.SubMessage{
+							topic: messages,
+						},
+					)
 				},
-			},
-		)
-	})
-
-	AfterEach(func() {
-		_ = subject.Close()
-	})
-
-	Describe("Subscribe", func() {
-		It("should handle messages", func() {
-			var handled []bps.SubMessage
-			handler := bps.HandlerFunc(func(msg bps.SubMessage) error {
-				handled = append(handled, msg)
-				return nil
-			})
-
-			Expect(subject.Subscribe(ctx, "foo", handler)).To(Succeed())
-
-			Expect(handled).To(Equal([]bps.SubMessage{
-				bps.RawSubMessage("foo1"),
-				bps.RawSubMessage("foo2"),
-			}))
+			}
 		})
 
-		It("should not fail on unknown topic", func() {
-			Expect(subject.Subscribe(ctx, "bar", noop)).To(Succeed())
-		})
-
-		It("should return handler error", func() {
-			err := errors.New("oops")
-			handler := bps.HandlerFunc(func(bps.SubMessage) error { return err })
-
-			Expect(subject.Subscribe(ctx, "foo", handler)).To(MatchError(err))
-		})
-
-		It("should check context", func() {
-			canceledCtx, cancel := context.WithCancel(context.Background())
-			cancel()
-
-			Expect(subject.Subscribe(canceledCtx, "foo", noop)).To(MatchError(context.Canceled))
-		})
+		lint.Subscriber(&shared)
 	})
 })


### PR DESCRIPTION
Decided to start with quite simple `file` consumer in the end - to polish lint.Subscriber.