### PR TITLE
subscribe: handler should not return any errors

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -48,9 +48,8 @@ func ExampleSubscriber() {
 	)
 	defer sub.Close()
 
-	handler := bps.HandlerFunc(func(msg bps.SubMessage) error {
+	handler := bps.HandlerFunc(func(msg bps.SubMessage) {
 		fmt.Printf("%s\n", msg.Data())
-		return nil // or bps.Done to stop/unsubscribe
 	})
 
 	// blocks till all the messages are consumed or error occurs:

--- a/file/example_test.go
+++ b/file/example_test.go
@@ -59,12 +59,11 @@ func ExampleSubscriber() {
 	}
 	defer sub.Close()
 
-	handler := bps.HandlerFunc(func(msg bps.SubMessage) error {
+	handler := bps.HandlerFunc(func(msg bps.SubMessage) {
 		fmt.Printf("%s\n", msg.Data())
-		return nil // or bps.Done to stop/unsubscribe
 	})
 
-	// blocks till all the messages are consumed or error occurs:
+	// blocks till all the messages are consumed:
 	err = sub.Topic("topic").Subscribe(ctx, handler)
 	if err != nil {
 		panic(err.Error())

--- a/file/file.go
+++ b/file/file.go
@@ -4,7 +4,6 @@ package file
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/url"
 	"os"
 	"path"
@@ -161,11 +160,7 @@ func (t SubTopic) Subscribe(ctx context.Context, handler bps.Handler, _ ...bps.S
 			return err
 		}
 
-		if err := handler.Handle(msg); errors.Is(err, bps.Done) {
-			break
-		} else if err != nil {
-			return err
-		}
+		handler.Handle(msg)
 	}
 	return nil
 }

--- a/kafka/example_test.go
+++ b/kafka/example_test.go
@@ -32,12 +32,11 @@ func ExampleSubscriber() {
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
-	// will block till context is cancelled or handler returns error:
+	// will block till context is cancelled:
 	err = sub.Topic("topic").Subscribe(
 		ctx,
-		bps.HandlerFunc(func(msg bps.SubMessage) error {
+		bps.HandlerFunc(func(msg bps.SubMessage) {
 			_, _ = fmt.Printf("%s\n", string(msg.Data()))
-			return nil // or bps.Done to unsubscribe
 		}),
 		bps.StartAt(bps.PositionOldest),
 	)

--- a/nats/example_test.go
+++ b/nats/example_test.go
@@ -32,12 +32,11 @@ func ExampleSubscriber() {
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
-	// will block till context is cancelled or handler returns error:
+	// will block till context is cancelled:
 	err = sub.Topic("topic").Subscribe(
 		ctx,
-		bps.HandlerFunc(func(msg bps.SubMessage) error {
+		bps.HandlerFunc(func(msg bps.SubMessage) {
 			_, _ = fmt.Printf("%s\n", string(msg.Data()))
-			return nil // or bps.Done to unsubscribe
 		}),
 		bps.StartAt(bps.PositionOldest),
 	)

--- a/nats/nats.go
+++ b/nats/nats.go
@@ -13,7 +13,6 @@ package nats
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -150,14 +149,7 @@ func (t *subTopic) Subscribe(ctx context.Context, handler bps.Handler, options .
 			default:
 			}
 
-			if err := handler.Handle(bps.RawSubMessage(msg.Data)); errors.Is(err, bps.Done) {
-				// stop normally, still acknowledge message:
-				stop(nil)
-			} else if err != nil {
-				// stop with error, do not acknowledge message:
-				stop(err)
-				return
-			}
+			handler.Handle(bps.RawSubMessage(msg.Data))
 
 			if err := msg.Ack(); err != nil {
 				stop(err)


### PR DESCRIPTION
Preparing for non-blocking subscription - trying to follow nats (stan) API 1-to-1.
No need to complicate this lib with handler errors.